### PR TITLE
Fixed label for input in form, and select widget

### DIFF
--- a/bootstrap_italia_template/templates/bootstrap-italia-base.html
+++ b/bootstrap_italia_template/templates/bootstrap-italia-base.html
@@ -22,8 +22,6 @@
         <link rel="stylesheet" href="{% django_bootstrap_italia_static_path 'css/bootstrap-italia.min.css' %}">
         <!-- Fonts -->
         <script>window.__PUBLIC_PATH__ = "{% django_bootstrap_italia_static_path 'fonts' %}"</script>
-        <!-- Javascript -->
-        <script src="{% django_bootstrap_italia_static_path 'js/bootstrap-italia.bundle.min.js' %}"></script>
 <!--
         <script src="{% django_bootstrap_italia_static_path 'js/vendor/owl.carousel.min.js' %}"></script>
 -->
@@ -557,6 +555,8 @@
         </footer>
         {% endblock footer %}
 
+        <script src="{% django_bootstrap_italia_static_path 'js/bootstrap-italia.bundle.min.js' %}"></script>
+        
         {% block bottom_scripts %}{% endblock bottom_scripts %}
         {% block extra_scripts %}{% endblock extra_scripts %}
     </body>

--- a/bootstrap_italia_template/templates/widgets/select.html
+++ b/bootstrap_italia_template/templates/widgets/select.html
@@ -1,3 +1,3 @@
-<div class="bootstrap-select-wrapper">
+<div class="select-wrapper">
     {% include "django/forms/widgets/select.html" %}
 </div>


### PR DESCRIPTION
Risolto il problema per cui le label degli input nelle form non venivano animate correttamente e aggiornata la classe per il campo `select`.